### PR TITLE
allow multiple error catching

### DIFF
--- a/remote_object/client.py
+++ b/remote_object/client.py
@@ -1,23 +1,31 @@
 # TODO:
 #     - Modify timeout functionality to allow longer timescale method calls
-#     - Add secondary client method which allows method calls on the server 
+#     - Add secondary client method which allows method calls on the server
 #         (not just the pyobj wrapped by the server)
 
 import socket
 import pickle
 
-from .errors import CallMethodError
+from .errors import CallMethodError as _CallMethodError
+
+def mixin_error(error,msg=""):
+    # Create new error which inherits from both the base
+    #  class and _CallMethodError, so the new error can
+    #  be caught by both execpt types
+    class CallMethodError(error__class__,_CallMethodError):
+        pass
+    return CallMethodError(msg)
 
 # The choice of BUFFER_SIZE and TIMEOUT are somewhat arbitrary,
 #  it would be good in the future to test some ideal values,
-#  or at least let the user choose these when instantiating 
+#  or at least let the user choose these when instantiating
 #  a client class.
 BUFFER_SIZE = 1024
 TIMEOUT = 3 # seconds
 
 class Client:
     """A remote_object Client.
-    
+
     This class allows a use to check attributes and make method calls
     on a python object hosted by the server.Server class. This is
     achieved by making a method call on the client.Client instance,
@@ -25,53 +33,53 @@ class Client:
     actually makes the requested method call and passes any return
     values or Exceptions back to the client to be returned or raised
     respectively.
-    
+
     :param __ip: A string holding the address of the server.Server
                     instance which the Client will call from.
-                    
+
     :param __port: An integer holding the port number of the server.Server
                     instance which the Client will call from
-                    
-    :method __call_method: The private method which actually parses the 
+
+    :method __call_method: The private method which actually parses the
                             client-requested call, passes this to the
                             server and then returns/raises the result.
                             This is not intended to be directly used.
-                            
+
     :Note: The Client class treats attribute lookups like method calls,
             but without arguments. So if the server-hosted python object
             has an attribute "a" it can be check by the Client class as
             client.Client(...).a()
-    
+
     Example Usage::
-        
+
         _client = client.Client('some ip',9999)
-        
+
         # Attempts to call ".a()" on server,
         #  may return a value or error, depending
         #  on the hosted object
         print(_client.a())
-        
+
         # Same as above
         print(_client.__getattr__("a")())
-        
+
         # Raises AttributeError, since the client.Client
         #  class does not have a natuarl method "a"
         print(_client.__getattribute__("a")())
     """
     def __init__(self,ip,port):
         self.__ip,self.__port = ip,port
-    
+
     def __repr__(self):
         try:
             _repr = self.__call_method("__repr__")
         except:
             _repr = "pointed at {0}:{1}".format(self.__ip,self.__port)
         return "<Remote Wrapper {}>".format(_repr)
-    
+
     def __call_method(self,fname,*args,**kwargs):
         """Handler for method calls and returns
-        
-        This method takes a 
+
+        This method takes a
         """
         socket = MessageSocket(self.__ip,self.__port)
         rmsg = socket.send_message(pickle.dumps((fname,args,kwargs)))
@@ -82,9 +90,12 @@ class Client:
             #  In that case, return_values is an error.TraceableError
             #  type, hence it is called during reraising so as to print
             #  the server traceback
-            raise CallMethodError("Remote Method Call Failed") from return_value()
+            error = return_value()
+            # Using mixin_error allows any try ... except .... statments to
+            #  catch either from `error.__class__` OR from `ro.errors.CallMethodError`
+            raise mixin_error(error,"Remote Method Call Failed") from error
         return return_value
-    
+
     def __getattr__(self,key):
         def f(*args,**kwargs):
             return self.__call_method(key,*args,**kwargs)
@@ -92,9 +103,9 @@ class Client:
 
 class MessageSocket(socket.socket):
     """A TCP socket wrapper for use by a remote_object.client.Client instance
-    
-    This class inherits from the base socket.socket class, see that 
-    documentation for details on the TCP socket connection. The 
+
+    This class inherits from the base socket.socket class, see that
+    documentation for details on the TCP socket connection. The
     main extension of this class is implement a single method to
     both send and receive a message, since when functioning properly,
     the server should always send a single response for the single message
@@ -106,13 +117,13 @@ class MessageSocket(socket.socket):
                                socket.SOCK_STREAM)
         self.settimeout(TIMEOUT)
         self.connect((ip,port))
-        
+
     def send_message(self,msg):
         """Sends a message, waits and returns the response
-        
+
         :param msg: a bytes type containing the messasge to
                     be send (note, do NOT include a term char)
-        
+
         :return rmsg: a bytes type containing the response
                         to the message (note, does NOT include
                         a term char)

--- a/remote_object/errors.py
+++ b/remote_object/errors.py
@@ -1,6 +1,6 @@
 # TODO:
 #     - Add error logging to TraceableError for server-side and error logging
-#         for client-side which are better than just a 'print' 
+#         for client-side which are better than just a 'print'
 #     - Change TraceableError to actually inhert from error, and just override
 #         whatever happens when raise gets called.
 
@@ -10,45 +10,45 @@ class CallMethodError(Exception):
     """Exception to raise on client when server has error.
     """
     pass
-        
+
 class TraceableError(Exception):
     """Exception wrapper which saves the traceback for pickling
-    
+
     This class is intended to allow the text of error tracebacks
-    to be pickled and then printed when the unpickled error is 
+    to be pickled and then printed when the unpickled error is
     raised. This is currently handled by calling the TraceableError
     instance when the error is intended to be reraised (after unpickling).
-    
+
     :param error: An instance of some Exception type. The instance must
                     have a valid .__traceback__ attribute at the time of
                     instantiation for the TraceableError class. (which
                     should always be true of an Exception instance caught
                     by 'except Exception as e:')
-    
+
     :param traceback: A string representation of the text of the traceback,
                         as it would have been printed into a terminal if
                         .error (at the time of initizalization of the class)
                         was raised.
-    
+
     Example Usage::
-        
+
         import pickle
-        
+
         def a():
             return b()
-            
+
         def b():
             raise Exception("Failures Abound!")
-            
+
         try:
             a()
         except Exception as e:
             E = e
             E_trace = errors.TraceableError(e)
-        
+
         # still retains some traceback info
         raise pickle.loads(pickle.dumps(E_trace()))
-        
+
         # does not retain traceback info
         raise pickle.loads(pickle.dumps(E))
     """
@@ -56,7 +56,7 @@ class TraceableError(Exception):
         self.error = error
         self.traceback = "\n".join(traceback.format_tb(error.__traceback__))
         print(self.traceback)
-        
+
     def __call__(self):
         print("Traceback (From server):\n\n",self.traceback)
         return self.error

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="remote-object",
-    version="0.2.1",
+    version="0.2.2",
     author="Jonathan D B Van Schenck",
     author_email="vanschej@oregonstate.edu",
     description="A TCP-based server/client library for making method calls from a client to a python object on the server",


### PR DESCRIPTION
Currently the error raising functionality is unwieldy. All server-side errors which are passed to the client are raised as `error.CallMethodError` types. The server-side traceback is printed, but the client has no (easy) way to access what that error type was.
For instance, if they server can throw either `IndexError`s or `AttributeError`s the client won't be able to handle them separately, for example:
```python
try:
    client.throws_index_error()
except IndexError:
    print("I'm not caught")
except AttributeError:
    print("I'm not caught either")
except CallMethodError:
    print("but I am")
```
With this PR, however, the client-side errors are raised as a new blended error type which inherits both from the original server-side error and from `errors.CallMethodError`. This way, clients can handle specific error types from the server, and also handle all errors from the server more generally.